### PR TITLE
impl(internal/gitrepo): clone recursively (include submodules)

### DIFF
--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -55,12 +55,13 @@ func CloneOrOpen(ctx context.Context, dirpath, repoURL string) (*Repo, error) {
 // specified directory at dirpath.
 func Clone(ctx context.Context, dirpath, repoURL string) (*Repo, error) {
 	repo, err := git.PlainClone(dirpath, false, &git.CloneOptions{
-		URL:           repoURL,
-		Progress:      os.Stdout,
-		ReferenceName: plumbing.HEAD,
-		SingleBranch:  true,
-		Depth:         1,
-		Tags:          git.NoTags,
+		URL:               repoURL,
+		Progress:          os.Stdout,
+		ReferenceName:     plumbing.HEAD,
+		SingleBranch:      true,
+		Depth:             1,
+		Tags:              git.NoTags,
+		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
It's unclear whether this is actually needed or not - I can't see how the "default" is actually defaulting otherwise, but I may be missing something.