### PR TITLE
impl(internal/generate): add framework for flags

### DIFF
--- a/internal/generate/create.go
+++ b/internal/generate/create.go
@@ -24,10 +24,10 @@ func generatorCreateCommand() *command {
 		name:  "create",
 		short: "Create a new client library",
 		usage: "generator create [arguments]",
-		fs:    flag.NewFlagSet("create", flag.ContinueOnError),
+		flags: flag.NewFlagSet("create", flag.ContinueOnError),
 		run:   create,
 	}
-	c.fs.Usage = constructUsage(c.fs, c.short, c.usage, c.commands, false)
+	c.flags.Usage = constructUsage(c.flags, c.short, c.usage, c.commands, false)
 	return c
 }
 

--- a/internal/generate/create.go
+++ b/internal/generate/create.go
@@ -1,0 +1,36 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"context"
+	"flag"
+)
+
+func generatorCreateCommand() *command {
+	c := &command{
+		name:  "create",
+		short: "Create a new client library",
+		usage: "generator create [arguments]",
+		fs:    flag.NewFlagSet("create", flag.ContinueOnError),
+		run:   create,
+	}
+	c.fs.Usage = constructUsage(c.fs, c.short, c.usage, c.commands, false)
+	return c
+}
+
+func create(ctx context.Context) error {
+	return errNotImplemented
+}

--- a/internal/generate/flags.go
+++ b/internal/generate/flags.go
@@ -15,75 +15,60 @@
 package generate
 
 import (
+	"context"
 	"flag"
 	"fmt"
 )
 
-type config struct {
-	api      string
-	language string
+type command struct {
+	name     string
+	short    string
+	usage    string
+	fs       *flag.FlagSet
+	commands []*command
+	run      func(ctx context.Context) error
 }
 
-func parseFlags(cfg *config, args []string) (*config, error) {
-	flags := flag.NewFlagSet("", flag.ContinueOnError)
-	flags.StringVar(&cfg.api, "api", "", "name of API inside googleapis")
-	flags.StringVar(&cfg.language, "language", "", "specify from cpp, csharp, go, java, node, php, python, ruby, rust")
-
-	// We don't want to print the whole usage message on each flags
-	// error, so we set to a no-op and do the printing ourselves.
-	flags.Usage = func() {}
-	usage := func() {
-		fmt.Fprint(flags.Output(), `Generator generates client libraries for Google APIs.
-
-Usage:
-
-  generator [flags]
-
-Flags:
-
-`)
-		flags.PrintDefaults()
-		fmt.Fprintf(flags.Output(), "\n\n")
-	}
-
-	if err := flags.Parse(args); err != nil {
-		if err == flag.ErrHelp {
-			usage() // print usage only on help
+func (c *command) lookup(name string) *command {
+	for _, sub := range c.commands {
+		if sub.name == name {
+			return sub
 		}
-		return nil, err
 	}
-	if err := validateConfig(cfg); err != nil {
-		usage() // print usage only on help
-		return nil, err
-	}
-	return cfg, nil
+	return nil
 }
 
-func validateConfig(cfg *config) error {
-	if cfg.api == "" {
-		return fmt.Errorf("api must be provided")
+func generatorCommand() *command {
+	c := &command{
+		name:  "generator",
+		short: "Generator generates client libraries for Google APIs.",
+		usage: "generator <command> [arguments]",
+		commands: []*command{
+			generatorCreateCommand(),
+			generatorGenerateCommand(),
+		},
+		fs: flag.NewFlagSet("generator", flag.ContinueOnError),
+		// run is not set for generator because it is different than the
+		// others
 	}
+	c.fs.Usage = constructUsage(c.fs, c.short, c.usage, c.commands, false)
+	return c
+}
 
-	switch cfg.language {
-	case "cpp":
-		return errNotImplemented
-	case "dotnet":
-		return nil
-	case "go":
-		return errNotImplemented
-	case "java":
-		return errNotImplemented
-	case "node":
-		return errNotImplemented
-	case "php":
-		return errNotImplemented
-	case "python":
-		return errNotImplemented
-	case "ruby":
-		return errNotImplemented
-	case "rust":
-		return errNotImplemented
-	default:
-		return fmt.Errorf("invalid -language flag specified: %q", cfg.language)
+func constructUsage(fs *flag.FlagSet, short, usage string, commands []*command, hasFlags bool) func() {
+	output := fmt.Sprintf("%s\n\nUsage:\n\n  %s\n", short, usage)
+	if len(commands) > 0 {
+		output += "\nThe commands are:\n\n"
+		for _, c := range commands {
+			output += fmt.Sprintf("  %s  %s\n", c.name, c.short)
+		}
+	}
+	if hasFlags {
+		output += "\nFlags:\n\n"
+	}
+	return func() {
+		fmt.Fprint(fs.Output(), output)
+		fs.PrintDefaults()
+		fmt.Fprintf(fs.Output(), "\n\n")
 	}
 }

--- a/internal/generate/flags.go
+++ b/internal/generate/flags.go
@@ -24,7 +24,7 @@ type command struct {
 	name     string
 	short    string
 	usage    string
-	fs       *flag.FlagSet
+	flags    *flag.FlagSet
 	commands []*command
 	run      func(ctx context.Context) error
 }
@@ -47,11 +47,11 @@ func generatorCommand() *command {
 			generatorCreateCommand(),
 			generatorGenerateCommand(),
 		},
-		fs: flag.NewFlagSet("generator", flag.ContinueOnError),
+		flags: flag.NewFlagSet("generator", flag.ContinueOnError),
 		// run is not set for generator because it is different than the
 		// others
 	}
-	c.fs.Usage = constructUsage(c.fs, c.short, c.usage, c.commands, false)
+	c.flags.Usage = constructUsage(c.flags, c.short, c.usage, c.commands, false)
 	return c
 }
 

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -34,18 +34,18 @@ func generatorGenerateCommand() *command {
 		name:  "generate",
 		short: "Generate a new client library",
 		usage: "generator generate [arguments]",
-		fs:    flag.NewFlagSet("generate", flag.ContinueOnError),
+		flags: flag.NewFlagSet("generate", flag.ContinueOnError),
 		run:   generate,
 	}
-	c.fs.StringVar(&apiFlag, "api", "", "name of API inside googleapis")
-	c.fs.Func("language", "language to generate", func(language string) error {
+	c.flags.StringVar(&apiFlag, "api", "", "name of API inside googleapis")
+	c.flags.Func("language", "language to generate", func(language string) error {
 		if !supportedLanguages[language] {
 			return fmt.Errorf("invalid -language flag specified: %q", language)
 		}
 		languageFlag = language
 		return nil
 	})
-	c.fs.Usage = constructUsage(c.fs, c.short, c.usage, c.commands, true)
+	c.flags.Usage = constructUsage(c.flags, c.short, c.usage, c.commands, true)
 	return c
 }
 

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -1,0 +1,103 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generate
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/googleapis/generator/internal/gitrepo"
+)
+
+var (
+	apiFlag      string
+	languageFlag string
+)
+
+func generatorGenerateCommand() *command {
+	c := &command{
+		name:  "generate",
+		short: "Generate a new client library",
+		usage: "generator generate [arguments]",
+		fs:    flag.NewFlagSet("generate", flag.ContinueOnError),
+		run:   generate,
+	}
+	c.fs.StringVar(&apiFlag, "api", "", "name of API inside googleapis")
+	c.fs.Func("language", "language to generate", func(language string) error {
+		if !supportedLanguages[language] {
+			return fmt.Errorf("invalid -language flag specified: %q", language)
+		}
+		languageFlag = language
+		return nil
+	})
+	c.fs.Usage = constructUsage(c.fs, c.short, c.usage, c.commands, true)
+	return c
+}
+
+var supportedLanguages = map[string]bool{
+	"cpp":    false,
+	"dotnet": true,
+	"go":     false,
+	"java":   false,
+	"node":   false,
+	"php":    false,
+	"python": false,
+	"ruby":   false,
+	"rust":   false,
+}
+
+func generate(ctx context.Context) error {
+	googleapisRepo, err := cloneGoogleapis(ctx)
+	if err != nil {
+		return err
+	}
+	languageRepo, err := cloneLanguageRepo(ctx, languageFlag)
+	if err != nil {
+		return err
+	}
+	return runDocker(googleapisRepo.Dir, languageRepo.Dir, apiFlag)
+}
+
+const googleapisURL = "https://github.com/googleapis/googleapis"
+
+func cloneGoogleapis(ctx context.Context) (*gitrepo.Repo, error) {
+	repoPath := filepath.Join(os.TempDir(), "/generator-googleapis")
+	return gitrepo.CloneOrOpen(ctx, repoPath, googleapisURL)
+}
+
+func cloneLanguageRepo(ctx context.Context, language string) (*gitrepo.Repo, error) {
+	languageRepoURL := fmt.Sprintf("https://github.com/googleapis/google-cloud-%s", language)
+	repoPath := filepath.Join(os.TempDir(), fmt.Sprintf("/generator-google-cloud-%s", language))
+	return gitrepo.CloneOrOpen(ctx, repoPath, languageRepoURL)
+}
+
+const dotnetImageTag = "picard"
+
+func runDocker(googleapisDir, languageDir, api string) error {
+	args := []string{
+		"run",
+		"-v", fmt.Sprintf("%s:/apis", googleapisDir),
+		"-v", fmt.Sprintf("%s:/output", languageDir),
+		dotnetImageTag,
+		"--command=update",
+		"--api-root=/apis",
+		fmt.Sprintf("--api=%s", api),
+		"--output-root=/output",
+	}
+	return runCommand("docker", args...)
+}

--- a/internal/generate/run.go
+++ b/internal/generate/run.go
@@ -26,20 +26,20 @@ import (
 func Run(ctx context.Context, arg ...string) error {
 	cmd := generatorCommand()
 
-	if err := cmd.fs.Parse(arg); err != nil {
+	if err := cmd.flags.Parse(arg); err != nil {
 		return err
 	}
-	if len(cmd.fs.Args()) == 0 {
-		cmd.fs.Usage()
+	if len(cmd.flags.Args()) == 0 {
+		cmd.flags.Usage()
 		return fmt.Errorf("missing command")
 	}
 
-	c := cmd.fs.Args()[0]
+	c := cmd.flags.Args()[0]
 	sub := cmd.lookup(c)
 	if sub == nil {
 		return fmt.Errorf("invalid command: %q", c)
 	}
-	if err := sub.fs.Parse(arg[1:]); err != nil {
+	if err := sub.flags.Parse(arg[1:]); err != nil {
 		return err
 	}
 	return sub.run(ctx)

--- a/internal/generate/run.go
+++ b/internal/generate/run.go
@@ -20,56 +20,29 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
-
-	"github.com/googleapis/generator/internal/gitrepo"
 )
 
 func Run(ctx context.Context, arg ...string) error {
-	cfg := &config{}
-	cfg, err := parseFlags(cfg, arg)
-	if err != nil {
+	cmd := generatorCommand()
+
+	if err := cmd.fs.Parse(arg); err != nil {
 		return err
 	}
-	googleapisRepo, err := cloneGoogleapis(ctx)
-	if err != nil {
+	if len(cmd.fs.Args()) == 0 {
+		cmd.fs.Usage()
+		return fmt.Errorf("missing command")
+	}
+
+	c := cmd.fs.Args()[0]
+	sub := cmd.lookup(c)
+	if sub == nil {
+		return fmt.Errorf("invalid command: %q", c)
+	}
+	if err := sub.fs.Parse(arg[1:]); err != nil {
 		return err
 	}
-	languageRepo, err := cloneLanguageRepo(ctx, cfg.language)
-	if err != nil {
-		return err
-	}
-	return runDocker(googleapisRepo.Dir, languageRepo.Dir, cfg.api)
-}
-
-const googleapisURL = "https://github.com/googleapis/googleapis"
-
-func cloneGoogleapis(ctx context.Context) (*gitrepo.Repo, error) {
-	repoPath := filepath.Join(os.TempDir(), "/generator-googleapis")
-	return gitrepo.CloneOrOpen(ctx, repoPath, googleapisURL)
-}
-
-func cloneLanguageRepo(ctx context.Context, language string) (*gitrepo.Repo, error) {
-	languageRepoURL := fmt.Sprintf("https://github.com/googleapis/google-cloud-%s", language)
-	repoPath := filepath.Join(os.TempDir(), fmt.Sprintf("/generator-google-cloud-%s", language))
-	return gitrepo.CloneOrOpen(ctx, repoPath, languageRepoURL)
-}
-
-const dotnetImageTag = "picard"
-
-func runDocker(googleapisDir, languageDir, api string) error {
-	args := []string{
-		"run",
-		"-v", fmt.Sprintf("%s:/apis", googleapisDir),
-		"-v", fmt.Sprintf("%s:/output", languageDir),
-		dotnetImageTag,
-		"--command=update",
-		"--api-root=/apis",
-		fmt.Sprintf("--api=%s", api),
-		"--output-root=/output",
-	}
-	return runCommand("docker", args...)
+	return sub.run(ctx)
 }
 
 func runCommand(c string, args ...string) error {


### PR DESCRIPTION
Create a framework that supports multiple command options, each with different flags and functionality.

To see this in action, run:

```
go run ./cmd/generator -help
go run ./cmd/generator generate -help
go run ./cmd/generator create -help
```