### PR TITLE
impl(internal/generate): refactor generatorCommand

### DIFF
--- a/internal/generate/create.go
+++ b/internal/generate/create.go
@@ -23,11 +23,10 @@ func generatorCreateCommand() *command {
 	c := &command{
 		name:  "create",
 		short: "Create a new client library",
-		usage: "generator create [arguments]",
 		flags: flag.NewFlagSet("create", flag.ContinueOnError),
 		run:   create,
 	}
-	c.flags.Usage = constructUsage(c.flags, c.short, c.usage, c.commands, false)
+	c.flags.Usage = constructUsage(c.flags, c.name, false)
 	return c
 }
 

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -33,7 +33,6 @@ func generatorGenerateCommand() *command {
 	c := &command{
 		name:  "generate",
 		short: "Generate a new client library",
-		usage: "generator generate [arguments]",
 		flags: flag.NewFlagSet("generate", flag.ContinueOnError),
 		run:   generate,
 	}
@@ -45,7 +44,7 @@ func generatorGenerateCommand() *command {
 		languageFlag = language
 		return nil
 	})
-	c.flags.Usage = constructUsage(c.flags, c.short, c.usage, c.commands, true)
+	c.flags.Usage = constructUsage(c.flags, c.name, true)
 	return c
 }
 

--- a/internal/generate/run.go
+++ b/internal/generate/run.go
@@ -16,7 +16,6 @@ package generate
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
@@ -24,25 +23,14 @@ import (
 )
 
 func Run(ctx context.Context, arg ...string) error {
-	cmd := generatorCommand()
-
-	if err := cmd.flags.Parse(arg); err != nil {
+	cmd, err := parseArgs(arg)
+	if err != nil {
 		return err
 	}
-	if len(cmd.flags.Args()) == 0 {
-		cmd.flags.Usage()
-		return fmt.Errorf("missing command")
-	}
-
-	c := cmd.flags.Args()[0]
-	sub := cmd.lookup(c)
-	if sub == nil {
-		return fmt.Errorf("invalid command: %q", c)
-	}
-	if err := sub.flags.Parse(arg[1:]); err != nil {
+	if err := cmd.flags.Parse(arg[1:]); err != nil {
 		return err
 	}
-	return sub.run(ctx)
+	return cmd.run(ctx)
 }
 
 func runCommand(c string, args ...string) error {


### PR DESCRIPTION
The top-level command is not like the others. Refactor the construction of the top-level command and remove unnecessary fields from the command struct.

Fixes #20