### PR TITLE
fix: use 'generate' subcommand for dotnet container

### DIFF
--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -50,7 +50,7 @@ func runGenerate(googleapisDir, languageDir, apiPath string) error {
 		"-v", fmt.Sprintf("%s:/apis", googleapisDir),
 		"-v", fmt.Sprintf("%s:/output", languageDir),
 		dotnetImageTag,
-		"--command=update",
+		"generate",
 		"--api-root=/apis",
 		fmt.Sprintf("--api-path=%s", apiPath),
 		"--output=/output",


### PR DESCRIPTION
As seen in https://github.com/googleapis/google-cloud-dotnet/blob/ffc678a023abc9da786ed9ce3f10615d42f01ac1/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommand.cs#L44, there is no longer an update command.

Resolves `Configuration error: Unknown subcommand '--command=update'`

Note also the removal of `--commmand=`, as the container is looking for a command in arg[0] rather than processing flags as shown here: https://github.com/googleapis/google-cloud-dotnet/blob/ffc678a023abc9da786ed9ce3f10615d42f01ac1/tools/Google.Cloud.Tools.ReleaseManager/ContainerCommand.cs#L47-L53