### PR TITLE
feat: Implement the "generate" workflow

### DIFF
--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -27,6 +27,7 @@ var (
 	flagLanguage       string
 	flagOutput         string
 	flagPush           bool
+	flagBuild          bool
 )
 
 func addFlagAPIRoot(fs *flag.FlagSet) {
@@ -72,4 +73,8 @@ func addFlagGitHubToken(fs *flag.FlagSet) {
 
 func addFlagGeneratorInput(fs *flag.FlagSet) {
 	fs.StringVar(&flagGeneratorInput, "generator-input", "", "generator-input within the clone we've just created")
+}
+
+func addFlagBuild(fs *flag.FlagSet) {
+	fs.BoolVar(&flagBuild, "build", false, "whether to build the generated code")
 }

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -31,8 +31,8 @@ func Clean(ctx context.Context, image, repoRoot, apiPath string) error {
 	return runClean(image, repoRoot, apiPath)
 }
 
-func Build(ctx context.Context, image, repoRoot, apiPath string) error {
-	return runBuild(image, repoRoot, apiPath)
+func Build(ctx context.Context, image, rootOptionName, root, apiPath string) error {
+	return runBuild(image, rootOptionName, root, apiPath)
 }
 
 func Configure(ctx context.Context, language, apiRoot, apiPath, generatorInput string) error {
@@ -92,18 +92,21 @@ func runClean(image, repoRoot, apiPath string) error {
 	return runDocker(image, mounts, containerArgs)
 }
 
-func runBuild(image, repoRoot, apiPath string) error {
+func runBuild(image, rootName, root, apiPath string) error {
 	if image == "" {
 		return fmt.Errorf("image cannot be empty")
 	}
-	if repoRoot == "" {
-		return fmt.Errorf("repoRoot cannot be empty")
+	if rootName == "" {
+		return fmt.Errorf("rootName cannot be empty")
 	}
-	mounts := []string{fmt.Sprintf("%s:/repo", repoRoot)}
+	if root == "" {
+		return fmt.Errorf("root cannot be empty")
+	}
+	mounts := []string{fmt.Sprintf("%s:/%s", root, rootName)}
 	var containerArgs []string
 	containerArgs = append(containerArgs,
 		"build",
-		"--repo-root=/repo",
+		fmt.Sprintf("--%s=/%s", rootName, rootName),
 	)
 	if apiPath != "" {
 		containerArgs = append(containerArgs, fmt.Sprintf("--api-path=%s", apiPath))


### PR DESCRIPTION
This workflow is for "unconfigured generation, based only on the API definition". (This is only unconfigured in terms of any language-specific configuration which would live in generator-input; we'd still expect a service config etc.)

The new "build" flag says whether or not to attempt to build the result.

Currently only a single language is supported; we could potentially iterate over multiple specified languages instead.

When building "unconfigured" code, we pass "--generator-output" to the container, instead of "--repo-root", to indicate the nature of the code to be built.