### PR TITLE
feat: Allow a default repository to be specified via an environment variable

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -267,7 +267,13 @@ func deriveImage() string {
 	if flagImage != "" {
 		return flagImage
 	} else {
-		return fmt.Sprintf("google-cloud-%s-generator", flagLanguage)
+		defaultRepository := os.Getenv("GENERATOR_CLI_REPOSITORY")
+		relativeImage := fmt.Sprintf("google-cloud-%s-generator", flagLanguage)
+		if defaultRepository == "" {
+			return relativeImage
+		} else {
+			return fmt.Sprintf("%s/%s", defaultRepository, relativeImage)
+		}
 	}
 }
 


### PR DESCRIPTION
e.g. `export GENERATOR_CLI_REPOSITORY=us-docker.pkg.dev/my-project/my-repo`

Fixes #54

(Note that if an image is specified via `-image`, that's assume to be definitive.)