### PR TITLE
fix: go.mod declares 1.23 (no longer 1.23.0)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/generator
 
-go 1.23.0
+go 1.23
 
 require github.com/go-git/go-git/v5 v5.12.0
 


### PR DESCRIPTION
Resolves
https://fusion2.corp.google.com/invocations/8bc4fbf4-1d35-4821-ae0c-0715b994533b/targets/cloud-devrel%2Fclient-libraries%2Fcloud-sdk-production-pipeline%2Fcontinuous;config=default/log