### PR TITLE
feat: implement commit

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -336,7 +336,8 @@ func commitAll(ctx context.Context, repo *gitrepo.Repo) error {
 		slog.Info("No modifications to commit.")
 		return nil
 	}
-	slog.Debug(fmt.Sprintf("git.Status: %#v", status))
+
+	gitrepo.PrintStatus(ctx, repo)
 	// TODO: Use git status to create a meaningful commit message.
 	return gitrepo.Commit(ctx, repo, "Generator updates.")
 }

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -338,7 +338,7 @@ func commitAll(ctx context.Context, repo *gitrepo.Repo) error {
 	}
 
 	gitrepo.PrintStatus(ctx, repo)
-	// TODO: Use git status to create a meaningful commit message.
+	// TODO: Get commit message from googleapis
 	return gitrepo.Commit(ctx, repo, "Generator updates.")
 }
 

--- a/internal/container/container.go
+++ b/internal/container/container.go
@@ -173,7 +173,7 @@ func runCommand(c string, args ...string) error {
 	cmd := exec.Command(c, args...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
-	slog.Info(strings.Repeat("-", 80))
+	slog.Info(strings.Repeat("=", 80))
 	slog.Info(cmd.String())
 	slog.Info(strings.Repeat("-", 80))
 	return cmd.Run()

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -114,7 +114,7 @@ func Commit(ctx context.Context, repo *Repo, msg string) error {
 		return err
 	}
 	if status.IsClean() {
-		return fmt.Errorf("No modifications to commit.")
+		return fmt.Errorf("no modifications to commit")
 	}
 	commit, err := worktree.Commit(msg, &git.CommitOptions{})
 	if err != nil {

--- a/internal/gitrepo/gitrepo.go
+++ b/internal/gitrepo/gitrepo.go
@@ -20,9 +20,11 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
 )
 
 // Repo represents a git repository.
@@ -116,7 +118,13 @@ func Commit(ctx context.Context, repo *Repo, msg string) error {
 	if status.IsClean() {
 		return fmt.Errorf("no modifications to commit")
 	}
-	commit, err := worktree.Commit(msg, &git.CommitOptions{})
+	commit, err := worktree.Commit(msg, &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Google Cloud SDK",
+			Email: "noreply-cloudsdk@google.com",
+			When:  time.Now(),
+		},
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Resolves #69

Example build: https://fusion2.corp.google.com/invocations/ef4a832b-54f1-4dd7-9778-46f08539eee5/targets/cloud-devrel%2Fclient-libraries%2Fcloud-sdk-production-pipeline%2Fcontinuous;config=default/log

Also:
* Only throw an error in push() if push is requested.
* Minor formatting improvement ("thick line") to docker command output separators.
* Pretty-print the git status to the logs.